### PR TITLE
hotfix: コメントアウトしていた lambda.Start を有効化 (#24)

### DIFF
--- a/Lambda_deploy/main.go
+++ b/Lambda_deploy/main.go
@@ -76,7 +76,7 @@ func formatDuration(seconds int) string {
 
 func main() {
 	lambda.Start(handler)
-	handler()
+	// handler()
 }
 
 func handler() {


### PR DESCRIPTION
## 修正内容
コメントアウトの対象を lambda.Start から handler に変更。
これにより、Lambdaにdeploy時は`lambda.Start`を有効にできる。