### PR TITLE
refactor/split-files

### DIFF
--- a/Lambda_deploy/config.go
+++ b/Lambda_deploy/config.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/joho/godotenv"
+)
+
+// DevModeを定義（テスト時は開発モードを有効にする）
+const DevMode = true
+
+var DiscordToken string
+var TextChannelID string
+var CollectionName string
+
+// DevModeの設定を集約する関数
+func SetupDevMode() {
+	// 環境モードに応じた設定を行う
+	var envFile string
+	if DevMode {
+		envFile = ".env.dev"  // 開発環境用
+		CollectionName = "test_profiles" // 開発用コレクション
+		fmt.Println("現在、開発モードで実行中です。")
+	} else {
+		envFile = ".env.prod" // 本番環境用
+		CollectionName = "user_profiles" // 本番用コレクション
+		fmt.Println("現在、本番モードで実行中です。")
+	}
+
+	// 環境変数をロード
+	err := godotenv.Load(envFile)
+	if err != nil {
+		log.Fatalf("%sの読み込みに失敗しました: %v", envFile, err)
+	}
+
+	// Discordトークンの取得
+	DiscordToken = os.Getenv("DISCORDTOKEN")
+	if DiscordToken == "" {
+		log.Fatal("環境変数DISCORDTOKENが設定されていません")
+	}
+
+	// 環境モードに応じたメッセージ送信先のチャンネルID指定
+	TextChannelID = os.Getenv("DISCORDTEXTCHANNELID")
+	if TextChannelID == "" {
+		log.Fatal("環境変数DISCORDTEXTCHANNELIDが設定されていません")
+	}
+}

--- a/Lambda_deploy/discord.go
+++ b/Lambda_deploy/discord.go
@@ -3,9 +3,19 @@ package main
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/bwmarrin/discordgo"
 )
+
+// 秒を「○時間○分○秒」形式に変換する関数
+func formatDuration(seconds int) string {
+	duration := time.Duration(seconds) * time.Second
+	hours := int(duration.Hours())
+	minutes := int(duration.Minutes()) % 60
+	secs := int(duration.Seconds()) % 60
+	return fmt.Sprintf("%d時間%d分%d秒", hours, minutes, secs)
+}
 
 // Discordメッセージ送信用の関数（メイン関数から呼び出される）
 func SendMessages(s *discordgo.Session, channelID string, userDataList []UserData) {

--- a/Lambda_deploy/discord.go
+++ b/Lambda_deploy/discord.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// Discordメッセージ送信用の関数（メイン関数から呼び出される）
+func SendMessages(s *discordgo.Session, channelID string, userDataList []UserData) {
+	sendNormalMessage(s, channelID, userDataList)
+	sendEmbedMessage(s, channelID, userDataList)
+}
+
+// 通常のテキストメッセージを送信
+func sendNormalMessage(s *discordgo.Session, channelID string, userDataList []UserData) {
+	message := ""
+	for i := 0; i < 3 && i < len(userDataList); i++ {
+		if userDataList[i].WeeklyStayingTime > 0 {
+			message += fmt.Sprintf("<@%s> ", userDataList[i].UserID)
+		}
+	}
+	if message == "" {
+		return
+	}
+	_, err := s.ChannelMessageSend(channelID, message)
+	if err != nil {
+		fmt.Println("Error sending normal message:", err)
+	}
+}
+
+// Embedメッセージを送信
+func sendEmbedMessage(s *discordgo.Session, channelID string, userDataList []UserData) {
+	validUsers := []UserData{}
+	for _, user := range userDataList {
+		if user.WeeklyStayingTime > 0 {
+			validUsers = append(validUsers, user)
+		}
+	}
+
+	rankCount := len(validUsers)
+	title := fmt.Sprintf("🔥今週の滞在時間トップ%d🔥", rankCount)
+
+	var descriptionBuilder strings.Builder
+	if rankCount == 0 {
+		title = "今週の滞在者なし😢"
+		descriptionBuilder.WriteString("今週はもくもくしていませんでした…\n")
+	} else {
+		descriptionBuilder.WriteString("今週のもくもくを頑張ったユーザーはこちら！\n")
+	}
+
+	for i := 0; i < 3; i++ {
+		if i < rankCount {
+			userID := validUsers[i].UserID
+			stayingTime := formatDuration(validUsers[i].WeeklyStayingTime)
+
+			if i == 0 {
+				descriptionBuilder.WriteString("\n")
+			}
+
+			descriptionBuilder.WriteString(fmt.Sprintf("**%d位:** <@%s>\n**滞在時間:** %s\n", i+1, userID, stayingTime))
+		} else {
+			descriptionBuilder.WriteString(fmt.Sprintf("**%d位:** ---\n**滞在時間:** ---\n", i+1))
+		}
+	}
+
+	embed := &discordgo.MessageEmbed{
+		Title:       title,
+		Description: descriptionBuilder.String(),
+		Color:       0x00ff00,
+	}
+
+	_, err := s.ChannelMessageSendEmbed(channelID, embed)
+	if err != nil {
+		fmt.Println("Error sending embed message:", err)
+	}
+}

--- a/Lambda_deploy/firestore.go
+++ b/Lambda_deploy/firestore.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	"cloud.google.com/go/firestore"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+)
+
+// グローバル変数の宣言！
+var client *firestore.Client
+
+const (
+	ProjectID       = "peachtech-mokumoku" // プロジェクトID
+	CredentialsFile = "./peachtech-mokumoku-91af9d3931c9.json" // サービスアカウントの認証ファイル
+)
+
+// Firestoreクライアントの初期化
+func InitFirestore() (*firestore.Client, error) {
+	ctx := context.Background()
+	client, err := firestore.NewClient(ctx, ProjectID, option.WithCredentialsFile(CredentialsFile))
+	if err != nil {
+		log.Fatalf("Firestoreクライアントの初期化に失敗しました: %v", err)
+		return nil, err
+	}
+	return client, nil
+}
+
+// Firestoreからユーザーデータを取得する関数
+func ReadUserProfiles(ctx context.Context, client *firestore.Client) ([]UserData, error) {
+	var userDataList []UserData
+	// 指定したコレクションから"UserID","UserName","WeeklyStayingTime"フィールドを取得
+	docRefs := client.Collection(CollectionName).Select("UserID", "UserName", "WeeklyStayingTime").Documents(ctx)
+
+	// ドキュメントを反復処理して取得
+	for {
+		docSnap, err := docRefs.Next()
+		if err != nil {
+			// データの終わりを検知し、ループを終了
+			if err == iterator.Done {
+				break
+			}
+			log.Printf("Firestoreからのデータ取得エラー: %v", err)
+			return nil, err
+		}
+
+		// 取得したフィールドをマップ形式で取得し、構造体に変換してスライスに保存
+		data := docSnap.Data() // Data() でマップとして取得
+		if len(data) > 0 {
+			// UserData型にデータを格納
+			userData := UserData{
+				UserID:            data["UserID"].(string),
+				UserName:          data["UserName"].(string),
+				WeeklyStayingTime: int(data["WeeklyStayingTime"].(int64)),
+			}
+
+			// ユーザーデータをスライスに追加
+			userDataList = append(userDataList, userData)
+		}
+	}
+	return userDataList, nil
+}

--- a/Lambda_deploy/firestore.go
+++ b/Lambda_deploy/firestore.go
@@ -9,9 +9,6 @@ import (
 	"google.golang.org/api/option"
 )
 
-// グローバル変数の宣言！
-var client *firestore.Client
-
 const (
 	ProjectID       = "peachtech-mokumoku" // プロジェクトID
 	CredentialsFile = "./peachtech-mokumoku-91af9d3931c9.json" // サービスアカウントの認証ファイル

--- a/Lambda_deploy/go.mod
+++ b/Lambda_deploy/go.mod
@@ -4,7 +4,6 @@ go 1.23.0
 
 require (
 	cloud.google.com/go/firestore v1.17.0
-	github.com/aws/aws-lambda-go v1.47.0
 	github.com/bwmarrin/discordgo v0.28.1
 	github.com/joho/godotenv v1.5.1
 	google.golang.org/api v0.206.0

--- a/Lambda_deploy/go.sum
+++ b/Lambda_deploy/go.sum
@@ -12,8 +12,6 @@ cloud.google.com/go/firestore v1.17.0/go.mod h1:69uPx1papBsY8ZETooc71fOhoKkD70Q1
 cloud.google.com/go/longrunning v0.6.2 h1:xjDfh1pQcWPEvnfjZmwjKQEcHnpz6lHjfy7Fo0MK+hc=
 cloud.google.com/go/longrunning v0.6.2/go.mod h1:k/vIs83RN4bE3YCswdXC5PFfWVILjm3hpEUlSko4PiI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/aws/aws-lambda-go v1.47.0 h1:0H8s0vumYx/YKs4sE7YM0ktwL2eWse+kfopsRI1sXVI=
-github.com/aws/aws-lambda-go v1.47.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
 github.com/bwmarrin/discordgo v0.28.1 h1:gXsuo2GBO7NbR6uqmrrBDplPUx2T3nzu775q/Rd1aG4=
 github.com/bwmarrin/discordgo v0.28.1/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/Lambda_deploy/init.go
+++ b/Lambda_deploy/init.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+
+	"cloud.google.com/go/firestore"
+	"github.com/bwmarrin/discordgo"
+	"google.golang.org/api/option"
+)
+
+// Firestore クライアントの初期化
+func initFirestoreClient() (*firestore.Client, context.Context, error) {
+	ctx := context.Background()
+	client, err := firestore.NewClient(ctx, "peachtech-mokumoku", option.WithCredentialsFile(CredentialsFile))
+	if err != nil {
+		return nil, nil, err
+	}
+	return client, ctx, nil
+}
+
+// Discord セッションの初期化
+func initDiscordSession() (*discordgo.Session, error) {
+	dg, err := discordgo.New("Bot " + DiscordToken)
+	if err != nil {
+		return nil, err
+	}
+	return dg, nil
+}
+
+// ユーザーデータを読み込む
+func loadUserData(client *firestore.Client, ctx context.Context) ([]UserData, error) {
+	return ReadUserProfiles(ctx, client)
+}

--- a/Lambda_deploy/main.go
+++ b/Lambda_deploy/main.go
@@ -41,13 +41,13 @@ func handler() {
 
 	// Firestoreクライアントの設定、初期化
 	ctx := context.Background()
-	client, err := firestore.NewClient(ctx, "peachtech-mokumoku", option.WithCredentialsFile("./peachtech-mokumoku-91af9d3931c9.json"))
+	client, err := firestore.NewClient(ctx, "peachtech-mokumoku", option.WithCredentialsFile(CredentialsFile))
 	if err != nil {
 		log.Fatalf("Firestoreクライアントの初期化に失敗しました: %v", err)
 	}
 	// リソースの解放
 	defer client.Close()
-	
+
 	// Firestoreからユーザーデータを取得する
 	userDataList, err = ReadUserProfiles(ctx, client)
 	if err != nil {

--- a/Lambda_deploy/main.go
+++ b/Lambda_deploy/main.go
@@ -20,7 +20,6 @@ type UserData struct {
 
 // グローバル変数の宣言！（初期化はmain関数内で行う）
 var userDataList []UserData
-var err error
 
 // 秒を「○時間○分○秒」形式に変換する関数
 func formatDuration(seconds int) string {
@@ -42,7 +41,7 @@ func handler() {
 
 	// Firestoreクライアントの設定、初期化
 	ctx := context.Background()
-	client, err = firestore.NewClient(ctx, "peachtech-mokumoku", option.WithCredentialsFile("./peachtech-mokumoku-91af9d3931c9.json"))
+	client, err := firestore.NewClient(ctx, "peachtech-mokumoku", option.WithCredentialsFile("./peachtech-mokumoku-91af9d3931c9.json"))
 	if err != nil {
 		log.Fatalf("Firestoreクライアントの初期化に失敗しました: %v", err)
 	}

--- a/Lambda_deploy/main.go
+++ b/Lambda_deploy/main.go
@@ -47,8 +47,12 @@ func handler() {
 	}
 	// リソースの解放
 	defer client.Close()
+	
 	// Firestoreからユーザーデータを取得する
-	ReadUserProfiles(ctx, client)
+	userDataList, err = ReadUserProfiles(ctx, client)
+	if err != nil {
+		log.Fatalf("ユーザーデータの取得に失敗しました: %v", err)
+	}
 
 	// Discord APIに接続
 	dg, err := discordgo.New("Bot " + DiscordToken)

--- a/Lambda_deploy/main.go
+++ b/Lambda_deploy/main.go
@@ -47,7 +47,6 @@ func handler() {
 	}
 	// リソースの解放
 	defer client.Close()
-
 	// Firestoreからユーザーデータを取得する
 	ReadUserProfiles(ctx, client)
 
@@ -56,19 +55,17 @@ func handler() {
 	if err != nil {
 		log.Fatalf("Discordセッションの作成に失敗しました: %v", err)
 	}
-
 	// Botを起動し、Discordサーバーに接続
 	err = dg.Open()
 	if err != nil {
 		log.Fatalf("Discordサーバーへの接続に失敗しました: %v", err)
 	}
-
 	// Discordセッションの使用後、自動的にクローズ
 	defer dg.Close()
 
-	// 上位3名の情報をEmbed/通常のメッセージ形式に組み立てて送信
+	// メッセージ送信
 	SendMessages(dg, TextChannelID, userDataList)
 
-	// WeeklyStayingTimeをリセットする
+	// WeeklyStayingTimeのリセット
 	ResetWeeklyStayingTime(ctx, client, userDataList)
 }

--- a/Lambda_deploy/main.go
+++ b/Lambda_deploy/main.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"fmt"
 	"log"
-	"time"
 	//"github.com/aws/aws-lambda-go/lambda"
 )
 
@@ -11,15 +9,6 @@ type UserData struct {
 	UserID            string
 	UserName          string
 	WeeklyStayingTime int
-}
-
-// 秒を「○時間○分○秒」形式に変換する関数
-func formatDuration(seconds int) string {
-	duration := time.Duration(seconds) * time.Second
-	hours := int(duration.Hours())
-	minutes := int(duration.Minutes()) % 60
-	secs := int(duration.Seconds()) % 60
-	return fmt.Sprintf("%d時間%d分%d秒", hours, minutes, secs)
 }
 
 func main() {

--- a/Lambda_deploy/main.go
+++ b/Lambda_deploy/main.go
@@ -9,6 +9,7 @@ import (
 	"cloud.google.com/go/firestore"
 	"github.com/bwmarrin/discordgo"
 	"google.golang.org/api/option"
+	//"github.com/aws/aws-lambda-go/lambda"
 )
 
 type UserData struct {

--- a/Lambda_deploy/main.go
+++ b/Lambda_deploy/main.go
@@ -70,23 +70,5 @@ func handler() {
 	SendMessages(dg, TextChannelID, userDataList)
 
 	// WeeklyStayingTimeをリセットする
-	ResetWeeklyStayingTime(ctx)
-	
-}
-
-// すでに取得してあるユーザーデータのスライスを用い、WeeklyStayingTimeをリセットする関数
-func ResetWeeklyStayingTime(ctx context.Context) {
-	// 各ユーザーのWeeklyStayingTimeをリセット
-	for _, userData := range userDataList {
-		_, err := client.Collection(CollectionName).Doc(userData.UserID).Update(ctx, []firestore.Update{
-			{Path: "WeeklyStayingTime", Value: 0}, // WeeklyStayingTimeを0にリセット
-		})
-		if err != nil {
-			log.Printf("ユーザー %s のWeeklyStayingTimeのリセットに失敗しました: %v", userData.UserID, err)
-		} else {
-			log.Printf("ユーザー %s のWeeklyStayingTimeをリセットしました", userData.UserID)
-		}
-	}
-
-	fmt.Println("\nWeeklyStayingTimeがリセットされました。")
+	ResetWeeklyStayingTime(ctx, client, userDataList)
 }

--- a/Lambda_deploy/main.go
+++ b/Lambda_deploy/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"sort"
-	"strings"
 	"time"
 
 	"cloud.google.com/go/firestore"
@@ -72,97 +71,11 @@ func handler() {
 	defer dg.Close()
 
 	// 上位3名の情報をEmbed/通常のメッセージ形式に組み立てて送信
-	sendMessages(dg, TextChannelID)
+	SendMessages(dg, TextChannelID, userDataList)
 
 	// WeeklyStayingTimeをリセットする
 	ResetWeeklyStayingTime(ctx)
 	
-}
-
-func sendMessages(s *discordgo.Session, channelID string) {
-	sendNormalMessage(s, channelID, userDataList)
-	sendEmbedMessage(s, channelID, userDataList)
-}
-
-// Embedメッセージを送信する関数
-func sendEmbedMessage(s *discordgo.Session, channelID string, userDataList []UserData) {
-	// 滞在時間が0より大きいユーザーを抽出し、validUsersに保存
-	validUsers := []UserData{}
-	for _, user := range userDataList {
-		if user.WeeklyStayingTime > 0 {
-			validUsers = append(validUsers, user)
-		}
-	}
-
-	// validUsersより、滞在者数を取得
-	rankCount := len(validUsers)
-
-	// 滞在者数より、Embedのタイトルを動的に設定
-	title := fmt.Sprintf("🔥今週の滞在時間トップ%d🔥", rankCount)
-
-	var descriptionBuilder strings.Builder
-	if rankCount == 0 {
-		title = "今週の滞在者なし😢"
-		descriptionBuilder.WriteString("今週はもくもくしていませんでした…\n")
-	} else {
-		descriptionBuilder.WriteString("今週のもくもくを頑張ったユーザーはこちら！\n") // ← 最初に1回だけ改行
-	}
-
-	// 上位のユーザー情報を追加（最大3人）
-for i := 0; i < 3; i++ {
-    if i < rankCount {
-        userID := validUsers[i].UserID
-        stayingTime := formatDuration(validUsers[i].WeeklyStayingTime)
-
-        // 明確に改行を入れる
-        if i == 0 {
-            descriptionBuilder.WriteString("\n")
-        }
-
-        // ユーザー情報を追加（各順位の後に改行）
-        descriptionBuilder.WriteString(fmt.Sprintf("**%d位:** <@%s>\n**滞在時間:** %s\n", i+1, userID, stayingTime))
-    } else {
-        // 滞在者数が3以下の場合もフォーマットの形を統一
-        descriptionBuilder.WriteString(fmt.Sprintf("**%d位:** ---\n**滞在時間:** ---\n", i+1))
-    }
-}
-
-	// Embedメッセージを作成
-	embed := &discordgo.MessageEmbed{
-		Title:       title,
-		Description: descriptionBuilder.String(),
-		Color:       0x00ff00,
-	}
-
-	// DiscordチャンネルへEmbedメッセージを送信
-	_, err := s.ChannelMessageSendEmbed(channelID, embed)
-	if err != nil {
-		fmt.Println("Error sending embed message:", err)
-		return
-	}
-}
-
-// 通常のテキストメッセージを送信する関数
-func sendNormalMessage(s *discordgo.Session, channelID string, userDataList []UserData) {
-	message := ""
-	// 上位3名のユーザーをメンション形式で、1行で組み立て
-	for i := 0; i < 3 && i < len(userDataList); i++ {
-		// 滞在時間が 0 以下のユーザーはメンションしない
-		if userDataList[i].WeeklyStayingTime > 0 {
-			message += fmt.Sprintf("<@%s> ", userDataList[i].UserID)
-		}
-	}
-	// メッセージが空なら何も送らない
-	if message == "" {
-		return
-	}
-
-	// メンション付きのテキストメッセージを送信
-	_, err := s.ChannelMessageSend(channelID, message)
-	if err != nil {
-		fmt.Println("Error sending normal message:", err)
-		return
-	}
 }
 
 // Firestoreからユーザーデータを取得する関数

--- a/Lambda_deploy/reset.go
+++ b/Lambda_deploy/reset.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"cloud.google.com/go/firestore"
+)
+
+// すでに取得してあるユーザーデータのスライスを用い、WeeklyStayingTimeをリセットする関数
+func ResetWeeklyStayingTime(ctx context.Context, client *firestore.Client, userDataList []UserData) {
+	for _, userData := range userDataList {
+		_, err := client.Collection(CollectionName).Doc(userData.UserID).Update(ctx, []firestore.Update{
+			{Path: "WeeklyStayingTime", Value: 0},
+		})
+		if err != nil {
+			log.Printf("ユーザー %s のWeeklyStayingTimeのリセットに失敗しました: %v", userData.UserID, err)
+		} else {
+			log.Printf("ユーザー %s のWeeklyStayingTimeをリセットしました", userData.UserID)
+		}
+	}
+
+	fmt.Println("\nWeeklyStayingTimeがリセットされました。")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/yuto0/DiscordBot_mokumoku
+
+go 1.23.0


### PR DESCRIPTION
## ファイル分割の目的
現在の `main.go` は、設定処理から、セッション作成、イベント処理、FireStoreの利用まで、すべての処理が1ファイルに集約されており、可読性や保守性に問題がある。
将来的に機能が増えていくことを見越して、以下の理由からファイルを分割し、責任の明確な構造に整理する。
## 分割の理由
- 保守性の向上：機能毎の点検・修正しやすくなる
- 可読性の向上：コード全体の流れを把握しやすい ＋ エラー部分を絞りやすい
- 再利用性の向上：設定や共通処理を、他のファイルから呼び出せる
## 分割の手順
### 1. 設定系（config.go）
開発モード（DevMode）の判定、環境変数の読み込み、Firestoreコレクション名の切り替え、DiscordトークンやチャンネルIDの取得処理を分離する。
### 2. Discord関連処理（discord.go） 
テキストチャンネルへのメッセージ送信を分離する。
### 3. データベース処理（firestore.go）
Firestore関係の処理を分離する。
### 4. ユーザーデータのリセット処理（reset.go）

## 意識すること
- main.go は全体の流れを見せる設計図
- 個々の処理の責任はほかの関数に任せる = 「何をするか」に集中して分離する。
