### PR TITLE
表示する人数に合わせてタイトルが正しく動作するよう修正

### DIFF
--- a/Lambda_deploy/discord.go
+++ b/Lambda_deploy/discord.go
@@ -45,14 +45,14 @@ func SendMessages(s *discordgo.Session, channelID string, userDataList []UserDat
 func sendNormalMessage(s *discordgo.Session, channelID string, userDataList []UserData) {
 	validUsers := sortUsersByStayingTime(userDataList)
 
-	message := ""
+	mentionMessage := ""
 	for i := 0; i < 3 && i < len(validUsers); i++ {
-		message += fmt.Sprintf("<@%s> ", validUsers[i].UserID)
+		mentionMessage += fmt.Sprintf("<@%s> ", validUsers[i].UserID)
 	}
-	if message == "" {
+	if mentionMessage == "" {
 		return
 	}
-	_, err := s.ChannelMessageSend(channelID, message)
+	_, err := s.ChannelMessageSend(channelID, mentionMessage)
 	if err != nil {
 		fmt.Println("Error sending normal message:", err)
 	}
@@ -62,26 +62,26 @@ func sendNormalMessage(s *discordgo.Session, channelID string, userDataList []Us
 func sendEmbedMessage(s *discordgo.Session, channelID string, userDataList []UserData) {
 	validUsers := sortUsersByStayingTime(userDataList)
 
-	rankCount := len(validUsers)
-	maxDisplayRank := 3
-	displayRank := rankCount
+	rankedNum := len(validUsers)
+	maxRankNum := 3
+	showRankNum := rankedNum
 	// ユーザーが3以上の時は、テキストをトップ３で固定
-	if displayRank > maxDisplayRank {
-		displayRank = maxDisplayRank
+	if showRankNum > maxRankNum {
+		showRankNum = maxRankNum
 	}
 
-	title := fmt.Sprintf("🔥今週の滞在時間トップ%d🔥", displayRank)
+	title := fmt.Sprintf("🔥今週の滞在時間トップ%d🔥", showRankNum)
 	var descriptionBuilder strings.Builder
 
-	if rankCount == 0 {
+	if rankedNum == 0 {
 		title = "今週の滞在者なし😢"
 		descriptionBuilder.WriteString("今週はもくもくしていませんでした…\n")
 	} else {
 		descriptionBuilder.WriteString("今週のもくもくを頑張ったユーザーはこちら！\n")
 	}
 
-	for i := 0; i < maxDisplayRank; i++ {
-		if i < rankCount {
+	for i := 0; i < maxRankNum; i++ {
+		if i < rankedNum {
 			userID := validUsers[i].UserID
 			stayingTime := formatDuration(validUsers[i].WeeklyStayingTime)
 

--- a/Lambda_deploy/discord.go
+++ b/Lambda_deploy/discord.go
@@ -65,7 +65,7 @@ func sendEmbedMessage(s *discordgo.Session, channelID string, userDataList []Use
 	rankedNum := len(validUsers)
 	maxRankNum := 3
 	showRankNum := rankedNum
-	// ユーザーが3以上の時は、テキストをトップ３で固定
+	// ユーザーが3人より大きい場合は、テキストをトップ３で固定
 	if showRankNum > maxRankNum {
 		showRankNum = maxRankNum
 	}


### PR DESCRIPTION
## 【目的】
ランキングのタイトルと表示される順位が一致しないバグが発生していたため、表示する人数に合わせたタイトルの調整を行いました。
また、ランキングが滞在時間順に正しく並ばない現象が起きていたため、正しくソートされるよう関数を再構築しました。
## 【改善内容】
### 1. タイトルの表示人数の調整
元のコードでは、rankCount（データの総人数）をそのままタイトルに使っていたため、例えば6人いる場合に「トップ6🔥」と表示される問題がありました。しかし、実際に表示されるのは最大3人までだったため、矛盾が生じていました。
これを解消するため、新たにdisplayRankを導入し、表示する人数を制御するようにしました。rankCountとdisplayRankは別々に管理し、タイトルに表示する人数をdisplayRankで設定します。これにより、タイトルと実際に表示されるランク数が一致するようになりました。
### 2. ランキングのソート処理の修正
ランキングが滞在時間が多い順に並んでいなかった問題を修正しました。
sortUsersByStayingTimeという関数を追加し、正しく滞在時間順にユーザーをソートするようにしました。